### PR TITLE
fix(free): prevent server flooding after 5xx

### DIFF
--- a/packages/free/src/adapter.ts
+++ b/packages/free/src/adapter.ts
@@ -108,7 +108,12 @@ async function retryFetch(
     res = await fetch(...args);
     if (res.status >= 500) {
       console.error(`${res.status} in free session service, retrying!`);
+      await sleep(3000);
     }
   } while (res.status >= 500);
   return res;
+}
+
+async function sleep(ms: number) {
+  await new Promise((r) => setTimeout(r, ms));
 }

--- a/packages/free/src/adapter.ts
+++ b/packages/free/src/adapter.ts
@@ -2,7 +2,7 @@ class Storage {
   public jwt: string | undefined;
   constructor(
     private readonly token: string,
-    private readonly rootUrl = 'https://grammy-free-session.deno.dev',
+    private readonly rootUrl = 'https://grammy-free-session.deno.dev/api',
   ) {}
 
   async login() {

--- a/packages/free/src/adapter.ts
+++ b/packages/free/src/adapter.ts
@@ -104,11 +104,14 @@ async function retryFetch(
   ...args: Parameters<typeof fetch>
 ): ReturnType<typeof fetch> {
   let res: Awaited<ReturnType<typeof fetch>>;
+  let delay = 10; // ms
   do {
     res = await fetch(...args);
     if (res.status >= 500) {
       console.error(`${res.status} in free session service, retrying!`);
-      await sleep(3000);
+      await sleep(delay);
+      delay += delay; // exponential back-off
+      delay = Math.min(delay, 1000 * 60 * 60); // cap at 1 hour
     }
   } while (res.status >= 500);
   return res;


### PR DESCRIPTION
If a 5xx error occurs regularly, we must not retry immediately. This could cause millions of requests in short periods of time.

Closes #136 