### PR TITLE
chore: add missing supabase license and update years

### DIFF
--- a/packages/deta/LICENSE
+++ b/packages/deta/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 dcdunkan
+Copyright (c) 2022-2023 dcdunkan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/file/LICENSE
+++ b/packages/file/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Satont
+Copyright (c) 2021-2023 Satont
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/firestore/LICENSE
+++ b/packages/firestore/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 KnorpelSenf
+Copyright (c) 2021-2023 KnorpelSenf
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/free/LICENSE
+++ b/packages/free/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 KnorpelSenf
+Copyright (c) 2022-2023 KnorpelSenf
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mongodb/LICENSE
+++ b/packages/mongodb/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Satont
+Copyright (c) 2021-2023 Satont
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/prisma/LICENSE
+++ b/packages/prisma/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Daniel Haro
+Copyright (c) 2022-2023 Daniel Haro
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/psql/LICENSE
+++ b/packages/psql/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Satont
+Copyright (c) 2021-2023 Satont
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/redis/LICENSE
+++ b/packages/redis/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Satont
+Copyright (c) 2021-2023 Satont
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/supabase/LICENSE
+++ b/packages/supabase/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-2023 Satont
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/typeorm/LICENSE
+++ b/packages/typeorm/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Satont
+Copyright (c) 2021-2023 Satont
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Adds a license file for the supabase adapter.

Updates all other license years.