### PR TITLE
chore(mongodb): fix example of usage in readme

### DIFF
--- a/packages/mongodb/README.md
+++ b/packages/mongodb/README.md
@@ -34,11 +34,11 @@ You need to get a native connection and use it:
 
 ```ts
 import mongoose from "mongoose";
-import MongoStorage from "@grammyjs/storage-mongodb";
+import { MongoDBAdapter, ISession } from "@grammyjs/storage-mongodb";
 
 await mongoose.connect("mongodb://localhost:27017/test");
 
-const collection = mongoose.connection.db.collection<MongoStorage.ISession>(
+const collection = mongoose.connection.db.collection<ISession>(
   "sessions",
 );
 
@@ -46,6 +46,6 @@ bot.use(session({
     initial: (): SessionData => ({
         pizzaCount: 0,
     }),
-    storage: new MongoStorage.MongoDBAdapter({ collection }),
+    storage: new MongoDBAdapter({ collection }),
 }))
 ```


### PR DESCRIPTION
Updated imports form 
```js
import MongoStorage from "@grammyjs/storage-mongodb";
```
to 
```js
import { MongoDBAdapter, ISession } from "@grammyjs/storage-mongodb";
```
becouse version "^2.2.0" throws Error 
"The requested module '@grammyjs/storage-mongodb' does not provide an export named 'default'"