### PR TITLE
docs(prisma): add SessionData type to prismaAdapter

### DIFF
--- a/packages/prisma/examples/jsonSession.ts
+++ b/packages/prisma/examples/jsonSession.ts
@@ -14,7 +14,7 @@ async function bootstrap() {
   bot.use(
     session({
       initial: () => ({ counter: 0 }),
-      storage: new PrismaAdapter(prisma.session),
+      storage: new PrismaAdapter<SessionData>(prisma.session),
     })
   );
 


### PR DESCRIPTION
The <SessionData> specifies the type of data that the PrismaAdapter will be dealing with. By providing the correct type, you ensure that the adapter knows what kind of data it will be working with and can perform type checks during compilation. This prevents potential runtime errors that could arise from trying to access properties that don't exist on the session data.