### PR TITLE
feat(denokv): custom prefix support

### DIFF
--- a/packages/denokv/src/adapter.ts
+++ b/packages/denokv/src/adapter.ts
@@ -1,18 +1,19 @@
 import { StorageAdapter } from './deps.ts';
 
 export class DenoKVAdapter<T> implements StorageAdapter<T> {
-  constructor(private kv: Deno.Kv) {}
+  constructor(private kv: Deno.Kv, 
+              private prefix: Deno.KvKeyPart[] = ['sessions']) {}
 
   async read(key: string): Promise<T | undefined> {
-    const result = await this.kv.get(['sessions', key]);
+    const result = await this.kv.get([...this.prefix, key]);
     return result.value !== null ? result.value as T : undefined;
   }
 
   async write(key: string, value: T) {
-    await this.kv.set(['sessions', key], value);
+    await this.kv.set([...this.prefix, key], value);
   }
 
   async delete(key: string) {
-    await this.kv.delete(['sessions', key]);
+    await this.kv.delete([...this.prefix, key]);
   }
 }


### PR DESCRIPTION
Feature: allow custom prefix to store session data under specified key space. Currently all session data are stored under `["sessions"]` key space. This feature would allow users to supply custom key prefix like this:

```typescript
new DenoKVAdapter(kv, ["mybot", "server"]);
new DenoKVAdapter(kv, ["mybot", "instances"]);
new DenoKVAdapter(kv, ["mybot", "bot1", "chats"]);
new DenoKVAdapter(kv, ["mybot", "bot2", "chats"]);
```

Consider the use case where I have a bot server handling updates from multiple bot instances, each bot instance have their own users. This feature enables me to store server level, bot level and chat level data in different key space, so I can manage data more easily, e.g. statistics, storage management, etc.

