### PR TITLE
fix(supabase): allow supabase^2 as peer dependency

### DIFF
--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -40,7 +40,7 @@
     "@supabase/supabase-js": "^1.24.0"
   },
   "peerDependencies": {
-    "@supabase/supabase-js": "^1.0.0"
+    "@supabase/supabase-js": "^1.0.0 || ^2.0.0"
   },
   "keywords": [
     "grammy",


### PR DESCRIPTION
This PR adds a supabase^2 as allowed peer dependency to `@grammyjs/storage-supabase`