### PR TITLE
feat: add autoParseDates option to RedisAdapter

### DIFF
--- a/packages/redis/examples/deno.ts
+++ b/packages/redis/examples/deno.ts
@@ -14,7 +14,7 @@ const redisInstance = await connect({
 });
 
 //create storage
-const storage = new RedisAdapter({ instance: redisInstance, ttl: 10 });
+const storage = new RedisAdapter({ instance: redisInstance, ttl: 10, autoParseDates: true });
 
 // Create bot and register session middleware
 const bot = new Bot<MyContext>('');

--- a/packages/redis/examples/node.ts
+++ b/packages/redis/examples/node.ts
@@ -10,7 +10,7 @@ type MyContext = Context & SessionFlavor<SessionData>;
 const redisInstance = new IORedis('redis://localhost:6379/0');
 
 //create storage
-const storage = new RedisAdapter({ instance: redisInstance, ttl: 10 });
+const storage = new RedisAdapter({ instance: redisInstance, ttl: 10, autoParseDates: true });
 
 // Create bot and register session middleware
 const bot = new Bot<MyContext>('');


### PR DESCRIPTION
When you put dates in the session, they are serialized to a string in a ISO 8601 format to be stored in redis

when retrieving the session from redis the date fields are kept as strings.

Adding an option to automatically convert the ISO 8601string to dates. 