### PR TITLE
feat(free): add readKeys method to free session storage adapter

### DIFF
--- a/packages/free/src/adapter.ts
+++ b/packages/free/src/adapter.ts
@@ -25,11 +25,11 @@ class Storage {
 
   async call(
     method: 'GET' | 'POST' | 'DELETE',
-    key: string,
+    key?: string, // make key optional to allow global calls
     body?: string,
   ): Promise<string | undefined> {
     // perform request
-    const url = `${this.rootUrl}/session/${key}`;
+    const url = key ? `${this.rootUrl}/session/${key}` : `${this.rootUrl}/sessions`; // define url based on key
     const jwt = await this.login();
     const headers = { 'Authorization': `Bearer ${jwt}` };
     const response = await retryFetch(url, { method, body, headers });
@@ -77,6 +77,10 @@ export function freeStorage<T>(token: string, opts?: StorageOptions) {
   const storage = new Storage(token, opts?.rootUrl);
   if (opts?.jwt !== undefined) storage.jwt = opts.jwt;
   return {
+    async readKeys(): Promise<T> {
+      const keys = await storage.call('GET');
+      return keys === undefined ? undefined : JSON.parse(keys);
+    },
     async read(key: string): Promise<T> {
       const session = await storage.call('GET', key);
       return session === undefined ? undefined : JSON.parse(session);


### PR DESCRIPTION
### Adding the `readKeys` Method to the Free Session Storage Adapter  

#### **Problem**  
Right now, we have a `read` method that lets you read a session, but it requires a `key`. The question is... how do you get that `key`? Well, I don't know ;)  

#### **Solution**  
The new `readKeys` method helps you fetch all available keys, which you can then use with `read` to get specific session data.  

#### **Changes Due to `readKeys`**  
- `key` in `call` is now **optional**, allowing global requests.  
- The URL structure now depends on `key`:  
  - If `key` is provided, you want to read a specific session (like `read` does now).  
  - If `key` is missing, you want to retrieve **all session keys** (which `readKeys` now handles).  

#### **Notes**  
The endpoint `/sessions` used for `readKeys` is provided by the storage adapter server here:  
https://github.com/grammyjs/free-session-backend/blob/778a383057e7b8a244fdb2beee20542d8ce0867b/src/main.ts#L89

**PS:** Hope this helps someone in the future, just like it helped me today! Hihihi