### PR TITLE
fix(free): correct readAllKeys return type

### DIFF
--- a/packages/free/src/adapter.ts
+++ b/packages/free/src/adapter.ts
@@ -77,9 +77,9 @@ export function freeStorage<T>(token: string, opts?: StorageOptions) {
   const storage = new Storage(token, opts?.rootUrl);
   if (opts?.jwt !== undefined) storage.jwt = opts.jwt;
   return {
-    async readAllKeys(): Promise<T> {
+    async readAllKeys(): Promise<string[]> {
       const keys = await storage.call('GET');
-      return keys === undefined ? undefined : JSON.parse(keys);
+      return keys === undefined ? [] : JSON.parse(keys);
     },
     async read(key: string): Promise<T> {
       const session = await storage.call('GET', key);


### PR DESCRIPTION
readAllKeys() was typed as Promise<T> instead of Promise<string[]>, causing a type error when used as an iterable of strings. Also changed the empty case to return [] instead of undefined.

Also changed the empty case from returning `undefined` to `[]`, which is consistent with the interface contract — callers expect an iterable, not
  `undefined`.

Fixes #259