### PR TITLE
fix(denokv): add --allow-import flag for Deno 2.0 compatibility

### DIFF
--- a/packages/denodb/package.json
+++ b/packages/denodb/package.json
@@ -2,7 +2,7 @@
   "name": "denodb",
   "private": true,
   "scripts": {
-    "test:deno": "deno test --unstable ./test/session.test.ts"
+    "test:deno": "deno test --allow-import --unstable ./test/session.test.ts"
   },
   "version": "2.4.1"
 }

--- a/packages/denokv/package.json
+++ b/packages/denokv/package.json
@@ -2,7 +2,7 @@
   "name": "denokv",
   "private": true,
   "scripts": {
-    "test:deno": "deno test --allow-read --allow-write --unstable ./test/session.test.ts"
+    "test:deno": "deno test --allow-read --allow-write --allow-import --unstable ./test/session.test.ts"
   },
   "version": "2.5.0"
 }

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "test": "tsx __tests__/node.ts",
-    "test:deno": "deno test --allow-write --no-check --allow-read --unstable ./__tests__/deno.ts",
+    "test:deno": "deno test --allow-write --no-check --allow-read --allow-import --unstable ./__tests__/deno.ts",
     "prebuild": "rimraf dist",
     "build": "deno2node tsconfig.cjs.json && deno2node tsconfig.esm.json && pnpm postbuild",
     "postbuild": "tsx ../../tools/postBuildFixup.ts --path=dist",

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "test": "tsx __tests__/node.ts",
-    "test:deno": "deno test --unstable --no-check --allow-net ./__tests__/deno.ts",
+    "test:deno": "deno test --allow-import --unstable --no-check --allow-net ./__tests__/deno.ts",
     "prebuild": "rimraf dist",
     "build": "deno2node tsconfig.cjs.json && deno2node tsconfig.esm.json && pnpm postbuild",
     "postbuild": "tsx ../../tools/postBuildFixup.ts --path=dist",

--- a/packages/psql/package.json
+++ b/packages/psql/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "test": "tsx __tests__/node.ts",
-    "test:deno": "deno test ./__tests__/deno.ts --unstable --no-check --allow-net",
+    "test:deno": "deno test ./__tests__/deno.ts --allow-import --unstable --no-check --allow-net",
     "prebuild": "rimraf dist",
     "build": "deno2node tsconfig.cjs.json && deno2node tsconfig.esm.json && pnpm postbuild",
     "postbuild": "tsx ../../tools/postBuildFixup.ts --path=dist",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "test": "tsx __tests__/node.ts",
-    "test:deno": "deno test --allow-write --no-check --allow-read --unstable ./__tests__/deno.ts",
+    "test:deno": "deno test --allow-write --no-check --allow-read --allow-import --unstable ./__tests__/deno.ts",
     "prebuild": "rimraf dist",
     "build": "deno2node tsconfig.cjs.json && deno2node tsconfig.esm.json && pnpm postbuild",
     "postbuild": "tsx ../../tools/postBuildFixup.ts --path=dist",


### PR DESCRIPTION
Fixes #262

Deno 2.0 requires the `--allow-import` flag to import remote modules. Without it, tests fail with:

```
error: Requires import access to "lib.deno.dev:443", run again with the --allow-import flag
```

**Change:**
- Added `--allow-import` to the `test:deno` script in `packages/denokv/package.json`