### PR TITLE
feat(prisma): forward optional cacheStrategy to findUnique

### DIFF
--- a/packages/prisma/__tests__/cacheStrategy.ts
+++ b/packages/prisma/__tests__/cacheStrategy.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test, vi } from 'vitest';
+import { PrismaAdapter } from '../src';
+import type { SessionDelegate } from '../src';
+
+function makeDelegate() {
+  return {
+    findUnique: vi.fn().mockResolvedValue(null),
+    upsert: vi.fn().mockResolvedValue({ key: 'k', value: '{}' }),
+    delete: vi.fn().mockResolvedValue({ key: 'k', value: '{}' }),
+  } satisfies SessionDelegate;
+}
+
+describe('PrismaAdapter cacheStrategy', () => {
+  test('does not forward cacheStrategy when none is configured', async () => {
+    const delegate = makeDelegate();
+    const adapter = new PrismaAdapter(delegate);
+
+    await adapter.read('k');
+
+    expect(delegate.findUnique).toHaveBeenCalledTimes(1);
+    const arg = delegate.findUnique.mock.calls[0][0];
+    expect(arg).toEqual({ where: { key: 'k' } });
+    expect(arg).not.toHaveProperty('cacheStrategy');
+  });
+
+  test('forwards cacheStrategy to findUnique when configured', async () => {
+    const delegate = makeDelegate();
+    const cacheStrategy = { ttl: 60, swr: 300, tags: ['grammy_session'] };
+    const adapter = new PrismaAdapter(delegate, { cacheStrategy });
+
+    await adapter.read('k');
+
+    expect(delegate.findUnique).toHaveBeenCalledWith({
+      where: { key: 'k' },
+      cacheStrategy,
+    });
+  });
+
+  test('does not forward cacheStrategy to writes or deletes', async () => {
+    const delegate = makeDelegate();
+    const adapter = new PrismaAdapter(delegate, {
+      cacheStrategy: { ttl: 60 },
+    });
+
+    await adapter.write('k', { x: 1 } as never);
+    await adapter.delete('k');
+
+    const upsertArg = delegate.upsert.mock.calls[0][0];
+    const deleteArg = delegate.delete.mock.calls[0][0];
+    expect(upsertArg).not.toHaveProperty('cacheStrategy');
+    expect(deleteArg).not.toHaveProperty('cacheStrategy');
+  });
+});

--- a/packages/prisma/src/mod.ts
+++ b/packages/prisma/src/mod.ts
@@ -1,17 +1,40 @@
 import { type StorageAdapter } from 'grammy';
-import { SessionDelegate } from './types/SessionDelegate';
+import { CacheStrategy, SessionDelegate } from './types/SessionDelegate';
 
 export * from './types/SessionDelegate';
 
+export interface PrismaAdapterOptions {
+  /**
+   * Forwarded as `cacheStrategy` to the underlying Prisma `findUnique` call
+   * on every session read. Only has an effect with the
+   * [Prisma Accelerate](https://www.prisma.io/docs/accelerate/caching)
+   * extension loaded; it is a no-op on vanilla Prisma clients.
+   *
+   * Writes (`upsert`) and deletes are not cached — Accelerate only caches
+   * read queries.
+   */
+  cacheStrategy?: CacheStrategy;
+}
+
 export class PrismaAdapter<T> implements StorageAdapter<T> {
   private sessionDelegate: SessionDelegate;
+  private cacheStrategy?: CacheStrategy;
 
-  constructor(repository: SessionDelegate) {
+  constructor(
+    repository: SessionDelegate,
+    options: PrismaAdapterOptions = {},
+  ) {
     this.sessionDelegate = repository;
+    this.cacheStrategy = options.cacheStrategy;
   }
 
   async read(key: string) {
-    const session = await this.sessionDelegate.findUnique({ where: { key } });
+    const session = await this.sessionDelegate.findUnique({
+      where: { key },
+      ...(this.cacheStrategy
+        ? { cacheStrategy: this.cacheStrategy }
+        : {}),
+    });
     return session?.value ? (JSON.parse(session.value) as T) : undefined;
   }
 

--- a/packages/prisma/src/types/SessionDelegate.ts
+++ b/packages/prisma/src/types/SessionDelegate.ts
@@ -16,8 +16,24 @@ interface Update {
   value: string;
 }
 
+/**
+ * Cache options forwarded to the underlying Prisma delegate when
+ * [Prisma Accelerate](https://www.prisma.io/docs/accelerate/caching) is in use.
+ * Ignored by vanilla Prisma clients.
+ */
+export interface CacheStrategy {
+  /** Time-to-live in seconds. */
+  ttl?: number;
+  /** Stale-while-revalidate window in seconds. */
+  swr?: number;
+  /** Cache-invalidation tags (alphanumeric + underscore, up to 64 chars each). */
+  tags?: string[];
+}
+
 export interface SessionDelegate {
-  findUnique: (input: { where: Where }) => Promise<Session | null>;
+  findUnique: (
+    input: { where: Where; cacheStrategy?: CacheStrategy },
+  ) => Promise<Session | null>;
   upsert: (input: {
     where: Where;
     create: Create;


### PR DESCRIPTION
Closes #241.

Prisma Accelerate adds a \`cacheStrategy\` option (\`ttl\` / \`swr\` / \`tags\`) to read queries to use the global query cache. Users who pair \`@grammyjs/storage-prisma\` with the Accelerate extension currently can't pass this through — the adapter hard-codes \`findUnique({ where: { key } })\`.

## API

\`\`\`ts
new PrismaAdapter(prisma.session, {
  cacheStrategy: { ttl: 60, swr: 300, tags: [\"grammy_session\"] },
});
\`\`\`

When configured, the strategy is forwarded verbatim to the delegate's \`findUnique\` on every session read. Writes (\`upsert\`) and deletes do not take a cache strategy, per Accelerate's contract — only reads are cached.

## Changes

- \`src/mod.ts\`: new \`PrismaAdapterOptions\` second constructor arg with optional \`cacheStrategy\`. Backwards compatible — the previous single-arg constructor and the vanilla Prisma call path emit the exact same payload.
- \`src/types/SessionDelegate.ts\`: \`findUnique\`'s input type gains an optional \`cacheStrategy\` field. The field is optional, so a vanilla \`prisma.<model>\` delegate still satisfies the interface. Exports a \`CacheStrategy\` type so TypeScript users can reference it.
- \`__tests__/cacheStrategy.ts\` (new): three vitest cases covering the default path, the forwarded-on-read path, and the \"never on writes/deletes\" contract. Uses a mocked delegate so the test does not touch the database.

## Test plan

- [x] \`vitest run __tests__/cacheStrategy.ts\` — 3/3 pass.
- [x] \`tsc --noEmit\` on the prisma package is clean (unrelated \`moduleResolution=node10\` deprecation warning reproduces on \`main\`).
- [x] \`eslint\` on the changed files is clean (the pre-existing quote-style error in \`src/index.ts\` reproduces on \`main\`).
- DB-bound integration tests (\`session.ts\`, \`delete.ts\`) were not run locally since they require a live Postgres — the mocked test proves the plumbing and the existing suite continues to pass in CI unchanged.